### PR TITLE
Linkage between select fields reworks and other bugs fixed

### DIFF
--- a/fastscala/src/main/scala/com/fastscala/core/FSSystem.scala
+++ b/fastscala/src/main/scala/com/fastscala/core/FSSystem.scala
@@ -138,7 +138,7 @@ class FSContext(
     if (deleted) throw new Exception("Trying to get child of deleted context")
     page.key2FSContext.getOrElseUpdate(key, {
       val newContext = new FSContext(session, page, Some(this), debugLbl = debugLabel)
-      children += page.key2FSContext(key)
+      children += newContext
       logger.trace(s"Creating context ${newContext.fullPath} ($newContext)")
       newContext
     })

--- a/fastscala/src/main/scala/com/fastscala/js/Js.scala
+++ b/fastscala/src/main/scala/com/fastscala/js/Js.scala
@@ -44,7 +44,7 @@ case class RawJs(js: String) extends Js {
 
 object JsOps {
 
-  implicit class RichJs(js: Js) {
+  implicit class RichJs(val js: Js) extends AnyVal {
 
     def `_==`(other: Js): Js = Js(s"${js.cmd} == ${other.cmd}")
 

--- a/fastscala/src/main/scala/com/fastscala/js/rerenderers/RerendererDebugStatus.scala
+++ b/fastscala/src/main/scala/com/fastscala/js/rerenderers/RerendererDebugStatus.scala
@@ -10,10 +10,10 @@ object RerendererDebugStatus extends Enumeration {
 
   def Unsupported = Set("table", "thead", "tbody", "tfooter", "tr")
 
-  implicit class RichValue[E <: FSXmlEnv : FSXmlSupport](v: Value) {
+  implicit class RichValue(val v: Value) extends AnyVal {
     private def style(bgColor: String = "rgb(147 211 255 / 6%)") = s"width: 100%; height: 100%; position: absolute; top: 0; left: 0; text-align: right; color: #4b4b4b; background-color: $bgColor; font-weight: bold; padding: 2px 4px; border: 2px solid #6290bd;pointer-events: none; z-index: 10;"
 
-    def render(rendered: E#Elem): E#Elem = {
+    def render[E <: FSXmlEnv : FSXmlSupport](rendered: E#Elem): E#Elem = {
       if (v == RerendererDebugStatus.Enabled && !Unsupported.contains(implicitly[FSXmlSupport[E]].label(rendered))) {
         implicitly[FSXmlSupport[E]].transformContents(implicitly[FSXmlSupport[E]].transformAttribute(rendered, "style", _.getOrElse("") + ";position:relative;"), existing =>
           implicitly[FSXmlSupport[E]].concat(existing,

--- a/fastscala/src/main/scala/com/fastscala/utils/Missing.scala
+++ b/fastscala/src/main/scala/com/fastscala/utils/Missing.scala
@@ -7,7 +7,7 @@ object Missing extends Enumeration {
 
   val Session, Page, AnonPage, CallbackFunction, FileDownloadFunction, FileUploadFunction = Value
 
-  implicit class RichValue(v: Value) {
+  implicit class RichValue(val v: Value) extends AnyVal {
     def updateStats()(implicit fss: FSSystem): Unit = v match {
       case Session =>
         fss.stats.sessionNotFoundTotal.inc()

--- a/fs_circe/src/main/scala/com/fastscala/core/circe/CIrceSupport.scala
+++ b/fs_circe/src/main/scala/com/fastscala/core/circe/CIrceSupport.scala
@@ -6,7 +6,7 @@ import com.fastscala.js.Js
 
 object CIrceSupport {
 
-  implicit class FSContextWithCirceSupport(fsc: FSContext) {
+  implicit class FSContextWithCirceSupport(val fsc: FSContext) extends AnyVal {
 
     private def session = fsc.session
 

--- a/fs_scala_xml_support/src/main/scala/com/fastscala/xml/scala_xml/JS.scala
+++ b/fs_scala_xml_support/src/main/scala/com/fastscala/xml/scala_xml/JS.scala
@@ -10,5 +10,12 @@ object JS extends JsXmlUtils[FSScalaXmlEnv.type]()(FSScalaXmlSupport.fsXmlSuppor
   type ScalaXmlContentRerendererP[T] = ContentRerendererP[FSScalaXmlEnv.type, T]
   type ScalaXmlRerendererP[T] = RerendererP[FSScalaXmlEnv.type, T]
 
-  implicit class RichJs(js: Js) extends RichJsXmlUtils(js, JS)(FSScalaXmlSupport.fsXmlSupport)
+  implicit class RichJs(val js: Js) extends AnyVal {
+    def inScriptTag: scala.xml.Elem = JS.inScriptTag(js)
+
+    def printBeforeExec: Js = {
+      println("> " + js.cmd)
+      JS.consoleLog(js.cmd) & js
+    }
+  }
 }

--- a/fs_scala_xml_support/src/main/scala/com/fastscala/xml/scala_xml/ScalaXmlElemUtils.scala
+++ b/fs_scala_xml_support/src/main/scala/com/fastscala/xml/scala_xml/ScalaXmlElemUtils.scala
@@ -6,7 +6,7 @@ import com.fastscala.xml.scala_xml.ScalaXmlNodeSeqUtils.MkNSFromNodeSeq
 import java.util.regex.Pattern
 import scala.xml._
 
-trait ScalaXmlElemUtils {
+trait ScalaXmlElemUtils extends Any {
   def elem: Elem
 
   def attributeTransform(attrName: String, transform: Option[String] => String): Elem = {
@@ -113,7 +113,7 @@ trait ScalaXmlElemUtils {
 
 object ScalaXmlElemUtils {
 
-  implicit class RichElem(val elem: Elem) extends ScalaXmlElemUtils
+  implicit class RichElem(val elem: Elem) extends AnyVal with ScalaXmlElemUtils
 
   def showIf(b: Boolean)(ns: => NodeSeq): NodeSeq = if (b) ns else NodeSeq.Empty
 }

--- a/fs_scala_xml_support/src/main/scala/com/fastscala/xml/scala_xml/ScalaXmlNodeSeqUtils.scala
+++ b/fs_scala_xml_support/src/main/scala/com/fastscala/xml/scala_xml/ScalaXmlNodeSeqUtils.scala
@@ -4,7 +4,7 @@ import scala.xml.{Elem, NodeSeq, Unparsed}
 
 object ScalaXmlNodeSeqUtils {
 
-  implicit class MkNSFromNodeSeq(elems: Iterable[NodeSeq]) {
+  implicit class MkNSFromNodeSeq(val elems: Iterable[NodeSeq]) extends AnyVal {
     def mkNS: NodeSeq = {
       val sb = new StringBuilder()
       elems.foreach(sb append _)
@@ -17,7 +17,7 @@ object ScalaXmlNodeSeqUtils {
     }
   }
 
-  implicit class MkNSFromElems(elems: Iterable[Elem]) {
+  implicit class MkNSFromElems(val elems: Iterable[Elem]) extends AnyVal {
     def mkNS: NodeSeq = {
       val sb = new StringBuilder()
       elems.foreach(sb append _)
@@ -30,7 +30,7 @@ object ScalaXmlNodeSeqUtils {
     }
   }
 
-  implicit class ShowNS(ns: NodeSeq) {
+  implicit class ShowNS(val ns: NodeSeq) extends AnyVal {
     def showIf(b: Boolean): NodeSeq = if (b) ns else NodeSeq.Empty
   }
 }

--- a/fs_taskmanager/src/main/scala/com/fastscala/taskmanager/app/TasksPage.scala
+++ b/fs_taskmanager/src/main/scala/com/fastscala/taskmanager/app/TasksPage.scala
@@ -77,6 +77,8 @@ class TasksPage extends BasePage() {
         }
 
         override def seqRowsSource: Seq[Task] = DB().tasks.toSeq
+
+        override def actionsBtnToIncludeInTopDropdown: BSBtn = super.actionsBtnToIncludeInTopDropdown.sm.mx_2
       }
 
       override def widgetTopRight()(implicit fsc: FSContext): NodeSeq = super.widgetTopRight() ++
@@ -94,7 +96,7 @@ class TasksPage extends BasePage() {
                 hideAndRemoveAndDeleteContext()
             }
           }.installAndShow()
-        }).btn
+        }).btn ++ tasksTable.actionsDropdownBtnRenderer.render()
 
       override def widgetContents()(implicit fsc: FSContext): NodeSeq = tasksTable.render()
 

--- a/fs_taskmanager/src/main/scala/com/fastscala/taskmanager/app/UsersPage.scala
+++ b/fs_taskmanager/src/main/scala/com/fastscala/taskmanager/app/UsersPage.scala
@@ -54,6 +54,8 @@ class UsersPage extends BasePage() {
         }
 
         override def seqRowsSource: Seq[R] = DB().users.toSeq
+
+        override def actionsBtnToIncludeInTopDropdown: BSBtn = super.actionsBtnToIncludeInTopDropdown.sm.mx_2
       }
 
       override def widgetTopRight()(implicit fsc: FSContext): NodeSeq = super.widgetTopRight() ++
@@ -75,7 +77,7 @@ class UsersPage extends BasePage() {
                 hideAndRemoveAndDeleteContext()
             }
           }.installAndShow()
-        }).btn
+        }).btn ++ table.actionsDropdownBtnRenderer.render()
 
       override def widgetContents()(implicit fsc: FSContext): NodeSeq = table.render()
 

--- a/fs_templates/src/main/scala/com/fastscala/templates/form7/fields/multiselect/F7MultiSelectFieldBase.scala
+++ b/fs_templates/src/main/scala/com/fastscala/templates/form7/fields/multiselect/F7MultiSelectFieldBase.scala
@@ -47,6 +47,12 @@ abstract class F7MultiSelectFieldBase[T]()(implicit val renderer: MultiSelectF7F
 
   var currentRenderedOptions = Option.empty[(Seq[T], Map[String, T], Map[T, String])]
 
+  override def onEvent(event: F7Event)(implicit form: Form7, fsc: FSContext, hints: Seq[RenderHint]): Js = event match {
+    case ChangedField(field) if deps.contains(field) => reRender() & form.onEvent(ChangedField(this))
+    case ChangedField(f) if f == this => updateFieldStatus()
+    case _ => Js.void
+  }
+
   override def updateFieldStatus()(implicit form: Form7, fsc: FSContext, hints: Seq[RenderHint]): Js =
     super.updateFieldStatus() &
       currentRenderedOptions.flatMap({
@@ -71,14 +77,16 @@ abstract class F7MultiSelectFieldBase[T]()(implicit val renderer: MultiSelectF7F
         val errorsToShow: Seq[(F7Field, NodeSeq)] = if (shouldShowValidation_?) validate() else Nil
         showingValidation = errorsToShow.nonEmpty
 
-        currentRenderedValue = Some(currentValue)
-
         val renderedOptions: Seq[T] = options
         val ids2Option: Map[String, T] = renderedOptions.map(opt => fsc.session.nextID() -> opt).toMap
         val option2Id: Map[T, String] = ids2Option.map(_.swap)
         currentRenderedOptions = Some((renderedOptions, ids2Option, option2Id))
+
+        currentValue = currentValue.filter(!renderedOptions.contains(_))
+
+        currentRenderedValue = Some(currentValue)
         val optionsRendered = renderedOptions.map(opt => {
-          renderer.renderOption(currentRenderedValue.get.contains(opt), option2Id(opt), _option2NodeSeq(opt))
+          renderer.renderOption(currentValue.contains(opt), option2Id(opt), _option2NodeSeq(opt))
         })
 
         val onchangeJs = fsc.callback(Js.selectedValues(Js.elementById(elemId)), ids => {

--- a/fs_templates/src/main/scala/com/fastscala/templates/form7/fields/select/F7SelectFieldBase.scala
+++ b/fs_templates/src/main/scala/com/fastscala/templates/form7/fields/select/F7SelectFieldBase.scala
@@ -51,6 +51,12 @@ abstract class F7SelectFieldBase[T]()(implicit val renderer: SelectF7FieldRender
 
   var currentRenderedOptions = Option.empty[(Seq[T], Map[String, T], Map[T, String])]
 
+  override def onEvent(event: F7Event)(implicit form: Form7, fsc: FSContext, hints: Seq[RenderHint]): Js = event match {
+    case ChangedField(field) if deps.contains(field) => reRender() & form.onEvent(ChangedField(this))
+    case ChangedField(f) if f == this => updateFieldStatus()
+    case _ => Js.void
+  }
+
   override def updateFieldStatus()(implicit form: Form7, fsc: FSContext, hints: Seq[RenderHint]): Js =
     super.updateFieldStatus() &
       currentRenderedOptions.flatMap({
@@ -70,14 +76,16 @@ abstract class F7SelectFieldBase[T]()(implicit val renderer: SelectF7FieldRender
         val errorsToShow: Seq[(F7Field, NodeSeq)] = if (shouldShowValidation_?) validate() else Nil
         showingValidation = errorsToShow.nonEmpty
 
-        currentRenderedValue = Some(currentValue)
-
         val renderedOptions: Seq[T] = options
         val ids2Option: Map[String, T] = renderedOptions.map(opt => fsc.session.nextID() -> opt).toMap
         val option2Id: Map[T, String] = ids2Option.map(_.swap)
         currentRenderedOptions = Some((renderedOptions, ids2Option, option2Id))
+
+        if (!renderedOptions.contains(currentValue)) currentValue = defaultValue
+
+        currentRenderedValue = Some(currentValue)
         val optionsRendered = renderedOptions.map(opt => {
-          renderer.renderOption(currentRenderedValue.get == opt, option2Id(opt), _option2NodeSeq(opt))
+          renderer.renderOption(currentValue == opt, option2Id(opt), _option2NodeSeq(opt))
         })
 
         val onchangeJs = fsc.callback(Js.elementValueById(elemId), id => {

--- a/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/btn/BSBtnToogle.scala
+++ b/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/btn/BSBtnToogle.scala
@@ -10,7 +10,7 @@ import scala.xml.Elem
 
 object BSBtnToogle {
 
-  implicit class RichBSBtnToogler(btn: BSBtn) {
+  implicit class RichBSBtnToogler(val btn: BSBtn) extends AnyVal {
 
     def toggler(
                  get: () => Boolean,

--- a/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/helpers/BSClassesHelper.scala
+++ b/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/helpers/BSClassesHelper.scala
@@ -1,6 +1,6 @@
 package com.fastscala.templates.bootstrap5.helpers
 
-trait BSClassesHelper[T] {
+trait BSClassesHelper[T] extends Any {
 
   protected def withClass(clas: String): T
 

--- a/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/helpers/BSDataHelper.scala
+++ b/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/helpers/BSDataHelper.scala
@@ -1,6 +1,6 @@
 package com.fastscala.templates.bootstrap5.helpers
 
-trait BSDataHelper[T] {
+trait BSDataHelper[T] extends Any {
 
   protected def setAttribute(name: String, value: String): T
 

--- a/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/helpers/BSHelpers.scala
+++ b/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/helpers/BSHelpers.scala
@@ -6,34 +6,34 @@ import scala.xml.Elem
 
 object BSHelpers extends BSClassesHelper[Elem] with BasicElemsHelper {
 
-  implicit class RichElemBasicOps(val elem: Elem) extends ScalaXmlElemUtils
+  implicit class RichElemBasicOps(val elem: Elem) extends AnyVal with ScalaXmlElemUtils
 
   override protected def withClass(clas: String): Elem =
     FSScalaXmlSupport.fsXmlSupport.buildElem("div")().addClass(clas)
 
-  implicit class RichElemBootstrapClasses(val elem: Elem) extends BSClassesHelper[Elem] with BSDataHelper[Elem] {
+  implicit class RichElemBootstrapClasses(val elem: Elem) extends AnyVal with BSClassesHelper[Elem] with BSDataHelper[Elem] {
     override protected def withClass(clas: String): Elem = elem.addClass(clas)
 
     override protected def setAttribute(name: String, value: String): Elem = elem.withAttr((name, value))
   }
 
-  implicit class RichString(val classes: String) extends BSClassesHelper[String] {
+  implicit class RichString(val classes: String) extends AnyVal with BSClassesHelper[String] {
     override protected def withClass(clas: String): String = classes.trim + " " + clas.trim
   }
 
-  implicit class RichClassEnrichableMutable[T <: ClassEnrichableMutable](val enrichable: T) extends BSClassesHelper[T] {
+  implicit class RichClassEnrichableMutable[T <: ClassEnrichableMutable](val enrichable: T) extends AnyVal with BSClassesHelper[T] {
     override protected def withClass(clas: String): T = enrichable.addClass(clas)
   }
 
-  implicit class RichAttributeEnrichableMutable[T <: AttrEnrichableMutable](val enrichable: T) extends BSDataHelper[T] {
+  implicit class RichAttributeEnrichableMutable[T <: AttrEnrichableMutable](val enrichable: T) extends AnyVal with BSDataHelper[T] {
     override protected def setAttribute(name: String, value: String): T = enrichable.setAttribute(name, value)
   }
 
-  implicit class RichClassEnrichable[R](val enrichable: ClassEnrichableImmutable[R]) extends BSClassesHelper[R] {
+  implicit class RichClassEnrichable[R](val enrichable: ClassEnrichableImmutable[R]) extends AnyVal with BSClassesHelper[R] {
     override protected def withClass(clas: String): R = enrichable.addClass(clas)
   }
 
-  implicit class RichAttributeEnrichable[R](val enrichable: AttrEnrichableImmutable[R]) extends BSDataHelper[R] {
+  implicit class RichAttributeEnrichable[R](val enrichable: AttrEnrichableImmutable[R]) extends AnyVal with BSDataHelper[R] {
     override protected def setAttribute(name: String, value: String): R = enrichable.setAttribute(name, value)
   }
 }

--- a/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/modals/BSModal5Base.scala
+++ b/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/modals/BSModal5Base.scala
@@ -53,7 +53,7 @@ abstract class BSModal5Base extends ClassEnrichableMutable with Mutable {
 
   lazy val modalContentsFooterRenderer: ScalaXmlRerenderer = JS.rerenderable(_ => implicit fsc => renderModalFooterContent(), debugLabel = Some("modal-contents-footer"))
 
-  def append2DOM()(implicit fsc: FSContext): Js = JS.append2Body(renderModal())
+  def append2DOM()(implicit fsc: FSContext): Js = JS.append2Body(modalRenderer.render())
 
   def installAndShow(
                       backdrop: Boolean = true

--- a/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/utils/bs_icons.scala
+++ b/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/utils/bs_icons.scala
@@ -7,7 +7,7 @@ import scala.xml.Elem
 object BsIcn {
   type BsIcn = String
 
-  implicit class RichIcn(i: BsIcn) {
+  implicit class RichIcn(val i: BsIcn) extends AnyVal {
     def icn: Elem = FSScalaXmlSupport.fsXmlSupport.buildElem("i", "class" -> s"bi $i")()
   }
 

--- a/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/utils/fa_icons.scala
+++ b/fs_templates_bootstrap/src/main/scala/com/fastscala/templates/bootstrap5/utils/fa_icons.scala
@@ -7,7 +7,7 @@ import scala.xml.Elem
 object IcnFA {
   type FaIcn = String
 
-  implicit class RichIcn(i: FaIcn) {
+  implicit class RichIcn(val i: FaIcn) extends AnyVal {
     def icn: Elem = FSScalaXmlSupport.fsXmlSupport.buildElem("i", "class" -> i)()
   }
 


### PR DESCRIPTION
1. Linkage between select fields reworks. It seems when `ChangedField ` events received from other fields it depends on, it should `reRender` so its option elements can be updated. I think `F7SelectField`, `F7MultiSelectField` and `F7RadioField` should behavior like this, but some fields like `F7TextField` don't have to do this. Maybe missing other fields? 

2. newContext created by `getOrCreateContext` in FSSytem not added into `children`

3. BSModal5Base should call `modalRenderer.render()` when render first time to get correct `aroundId`. I'm not sure about this, but at least this behavior is consisted with `Widget.renderWidget()`

4. All implicit classes extends `AnyVal `to avoid the cost of objects creation when these implicit conversions occur.